### PR TITLE
Enhance plugins options

### DIFF
--- a/src/main/java/com/synaptix/sonar/plugins/gitlab/CommitProjectBuilder.java
+++ b/src/main/java/com/synaptix/sonar/plugins/gitlab/CommitProjectBuilder.java
@@ -30,20 +30,20 @@ import org.sonar.api.utils.MessageException;
  */
 public class CommitProjectBuilder extends ProjectBuilder {
 
-    private final GitLabPluginConfiguration gitLabPluginConfiguration;
+    private final GitLabPluginConfiguration configuration;
     private final GitLabApiFacade gitLabApiFacade;
     private final AnalysisMode mode;
 
-    public CommitProjectBuilder(GitLabPluginConfiguration gitLabPluginConfiguration, GitLabApiFacade gitLabApiFacade,
+    public CommitProjectBuilder(GitLabPluginConfiguration configuration, GitLabApiFacade gitLabApiFacade,
             AnalysisMode mode) {
-        this.gitLabPluginConfiguration = gitLabPluginConfiguration;
+        this.configuration = configuration;
         this.gitLabApiFacade = gitLabApiFacade;
         this.mode = mode;
     }
 
     @Override
     public void build(Context context) {
-        if (!gitLabPluginConfiguration.isEnabled()) {
+        if (!configuration.isEnabled()) {
             return;
         }
         if (!mode.isIssues()) {
@@ -52,7 +52,9 @@ public class CommitProjectBuilder extends ProjectBuilder {
         }
 
         gitLabApiFacade.init(context.projectReactor().getRoot().getBaseDir());
-        gitLabApiFacade.createCommitStatus(gitLabPluginConfiguration.getBuildInitState(),
-                "SonarQube analysis in progress");
+        if (configuration.statusNotificationMode().equals("commit-status")) {
+            gitLabApiFacade.createCommitStatus(configuration.commitHashes().get(0), configuration.getBuildInitState(),
+                    "SonarQube analysis in progress");
+        }
     }
 }

--- a/src/main/java/com/synaptix/sonar/plugins/gitlab/GitLabPlugin.java
+++ b/src/main/java/com/synaptix/sonar/plugins/gitlab/GitLabPlugin.java
@@ -36,14 +36,18 @@ public class GitLabPlugin implements Plugin {
     static final String GITLAB_MAX_GLOBAL_ISSUES = "sonar.gitlab.max_global_issues";
     static final String GITLAB_USER_TOKEN = "sonar.gitlab.user_token";
     static final String GITLAB_PROJECT_ID = "sonar.gitlab.project_id";
-    static final String GITLAB_COMMIT_SHA = "sonar.gitlab.commit_sha";
+    static final String GITLAB_COMMIT_HASHES = "sonar.gitlab.commit_hashes";
     static final String GITLAB_REF_NAME = "sonar.gitlab.ref_name";
-    static final String GITLAB_IGNORE_FILE = "sonar.gitlab.ignore_file";
-    static final String GITLAB_COMMENT_NO_ISSUE = "sonar.gitlab.comment_no_issue";
+    static final String GITLAB_GLOBAL_COMMENT_NO_ISSUE = "sonar.gitlab.comment_no_issue";
     static final String GITLAB_IGNORE_SSL = "sonar.gitlab.ignore_ssl";
     static final String GITLAB_BUILD_INIT_STATE = "sonar.gitlab.build_init_state";
+    static final String GITLAB_DISABLE_GLOBAL_COMMENT = "sonar.gitlab.disable_global_comment";
+    static final String GITLAB_STATUS_NOTIFICATION_MODE = "sonar.gitlab.failure_notification_mode";
 
     static final List<String> BUILD_INIT_STATES = Collections.unmodifiableList(Arrays.asList("pending", "running"));
+    private static final List<String> STATUS_NOTIFICATIONS_MODE = Collections.unmodifiableList(
+            Arrays.asList("commit-status", "exit-code")
+    );
 
     private static final String CATEGORY = "gitlab";
     private static final String INSTANCE_SUBCATEGORY = "instance";
@@ -90,9 +94,9 @@ public class GitLabPlugin implements Plugin {
                         .index(4)
                         .build(),
                 PropertyDefinition
-                        .builder(GITLAB_COMMIT_SHA)
-                        .name("Commit SHA")
-                        .description("The commit revision for which project is built.")
+                        .builder(GITLAB_COMMIT_HASHES)
+                        .name("Commit hashes")
+                        .description("The commit revisions that will be used by plugin to find issue on files.")
                         .category(CATEGORY)
                         .subCategory(REPORTING_SUBCATEGORY)
                         .hidden()
@@ -100,32 +104,22 @@ public class GitLabPlugin implements Plugin {
                         .build(),
                 PropertyDefinition
                         .builder(GITLAB_REF_NAME)
-                        .name("Ref name")
-                        .description("The commit revision for which project is built.")
+                        .name("Commit reference")
+                        .description("The commit reference for which project is built.")
                         .category(CATEGORY)
                         .subCategory(REPORTING_SUBCATEGORY)
                         .hidden()
                         .index(6)
                         .build(),
                 PropertyDefinition
-                        .builder(GITLAB_IGNORE_FILE)
-                        .name("Ignore unrelated files")
-                        .description("Ignore issues on files not modified by the commit.")
+                        .builder(GITLAB_GLOBAL_COMMENT_NO_ISSUE)
+                        .name("Global comment even when there is no new issues")
+                        .description("Add a global comment even when there is no new issue.")
                         .category(CATEGORY)
                         .subCategory(REPORTING_SUBCATEGORY)
                         .type(PropertyType.BOOLEAN)
                         .defaultValue(String.valueOf(false))
                         .index(7)
-                        .build(),
-                PropertyDefinition
-                        .builder(GITLAB_COMMENT_NO_ISSUE)
-                        .name("Comment if no new issues")
-                        .description("Add a comment even when there is no new issue.")
-                        .category(CATEGORY)
-                        .subCategory(REPORTING_SUBCATEGORY)
-                        .type(PropertyType.BOOLEAN)
-                        .defaultValue(String.valueOf(false))
-                        .index(8)
                         .build(),
                 PropertyDefinition
                         .builder(GITLAB_IGNORE_SSL)
@@ -135,7 +129,7 @@ public class GitLabPlugin implements Plugin {
                         .subCategory(INSTANCE_SUBCATEGORY)
                         .type(PropertyType.BOOLEAN)
                         .defaultValue(String.valueOf(false))
-                        .index(9)
+                        .index(8)
                         .build(),
                 PropertyDefinition
                         .builder(GITLAB_BUILD_INIT_STATE)
@@ -143,10 +137,30 @@ public class GitLabPlugin implements Plugin {
                         .description("State that should be the first when build commit status update is called.")
                         .category(CATEGORY)
                         .subCategory(REPORTING_SUBCATEGORY)
-                        .index(10)
+                        .index(9)
                         .type(PropertyType.SINGLE_SELECT_LIST)
                         .options(BUILD_INIT_STATES)
                         .defaultValue("running")
+                        .build(),
+                PropertyDefinition
+                        .builder(GITLAB_DISABLE_GLOBAL_COMMENT)
+                        .name("Disable global comment")
+                        .description("Disable global comment, report only inline.")
+                        .category(CATEGORY)
+                        .subCategory(REPORTING_SUBCATEGORY)
+                        .index(10)
+                        .defaultValue(String.valueOf(false))
+                        .build(),
+                PropertyDefinition
+                        .builder(GITLAB_STATUS_NOTIFICATION_MODE)
+                        .name("Status notification mode")
+                        .description("Status notification mode: commit-status or exit-code")
+                        .category(CATEGORY)
+                        .subCategory(REPORTING_SUBCATEGORY)
+                        .type(PropertyType.SINGLE_SELECT_LIST)
+                        .options(STATUS_NOTIFICATIONS_MODE)
+                        .index(11)
+                        .defaultValue("commit-status")
                         .build()
         );
     }

--- a/src/main/java/com/synaptix/sonar/plugins/gitlab/GitLabPluginConfiguration.java
+++ b/src/main/java/com/synaptix/sonar/plugins/gitlab/GitLabPluginConfiguration.java
@@ -23,6 +23,12 @@ import org.sonar.api.batch.InstantiationStrategy;
 import org.sonar.api.batch.ScannerSide;
 import org.sonar.api.config.Settings;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import javax.annotation.CheckForNull;
 
 @InstantiationStrategy(InstantiationStrategy.PER_BATCH)
@@ -35,28 +41,28 @@ public class GitLabPluginConfiguration {
         this.settings = settings;
     }
 
+    boolean isEnabled() {
+        return settings.hasKey(GitLabPlugin.GITLAB_COMMIT_HASHES);
+    }
+
     @CheckForNull
     String projectId() {
         return settings.getString(GitLabPlugin.GITLAB_PROJECT_ID);
     }
 
     @CheckForNull
-    String commitSHA() {
-        return settings.getString(GitLabPlugin.GITLAB_COMMIT_SHA);
+    List<String> commitHashes() {
+        return Arrays.asList(settings.getStringArray(GitLabPlugin.GITLAB_COMMIT_HASHES));
     }
 
     @CheckForNull
-    String refName() {
+    String referenceName() {
         return settings.getString(GitLabPlugin.GITLAB_REF_NAME);
     }
 
     @CheckForNull
     String userToken() {
         return settings.getString(GitLabPlugin.GITLAB_USER_TOKEN);
-    }
-
-    boolean isEnabled() {
-        return settings.hasKey(GitLabPlugin.GITLAB_COMMIT_SHA);
     }
 
     @CheckForNull
@@ -70,13 +76,8 @@ public class GitLabPluginConfiguration {
     }
 
     @CheckForNull
-    boolean ignoreFileNotModified() {
-        return settings.getBoolean(GitLabPlugin.GITLAB_IGNORE_FILE);
-    }
-
-    @CheckForNull
     boolean commentNoIssue() {
-        return settings.getBoolean(GitLabPlugin.GITLAB_COMMENT_NO_ISSUE);
+        return settings.getBoolean(GitLabPlugin.GITLAB_GLOBAL_COMMENT_NO_ISSUE);
     }
 
     @CheckForNull
@@ -87,5 +88,15 @@ public class GitLabPluginConfiguration {
     @CheckForNull
     String getBuildInitState() {
         return settings.getString(GitLabPlugin.GITLAB_BUILD_INIT_STATE);
+    }
+
+    @CheckForNull
+    boolean disableGlobalComment() {
+        return settings.getBoolean(GitLabPlugin.GITLAB_DISABLE_GLOBAL_COMMENT);
+    }
+
+    @CheckForNull
+    String statusNotificationMode() {
+        return settings.getString(GitLabPlugin.GITLAB_STATUS_NOTIFICATION_MODE);
     }
 }


### PR DESCRIPTION
- new `sonar.gitlab.commit_hashes` to support multiple hashes (fixes #4)
- new `sonar.gitlab.failure_notification_mode` to support exit code mode (fixes #11)
- new `sonar.gitlab.disable_global_comment` to disable global comment (fixes #9)