### PR TITLE
Try get projects before searching on list

### DIFF
--- a/src/main/java/com/synaptix/sonar/plugins/gitlab/GitLabApiFacade.java
+++ b/src/main/java/com/synaptix/sonar/plugins/gitlab/GitLabApiFacade.java
@@ -203,6 +203,12 @@ public class GitLabApiFacade {
         if (configuration.projectId() == null) {
             throw new IllegalStateException("Missing required attribute: " + GitLabPlugin.GITLAB_PROJECT_ID);
         }
+
+        GitlabProject project = gitLabApi.getProject(configuration.projectId());
+        if (project != null) {
+            return project;
+        }
+
         Set<GitlabProject> projects = Optional
                 .ofNullable(gitLabApi.getProjects())
                 .orElseThrow(() -> new IllegalStateException("Unable to find projects within: " + configuration.url()))


### PR DESCRIPTION
If user is part of group and not project, he has access to project but is not listed on project list api